### PR TITLE
Fixed return type of C++ TcpDataHandler signature

### DIFF
--- a/inc/MSocket.hpp
+++ b/inc/MSocket.hpp
@@ -52,7 +52,7 @@ public:
 
    typedef std::function<void(MSocketPtr)> TcpAcceptHandler;
    typedef std::function<void(const std::string&, PortNumberT)> ConnectHandler;
-   typedef std::function<uint8_t(const BufferDataT*, BufferSizeT, BufferSizeT&)> TcpDataHandler;
+   typedef std::function<bool(const BufferDataT*, BufferSizeT, BufferSizeT&)> TcpDataHandler;
    typedef std::function<void()> DisconnectedHandler;
    typedef std::function<void(uint32_t elapsed)> TcpInactivityHandler;
    typedef std::function<void(const std::string&, PortNumberT, const BufferDataT*, BufferSizeT)> UdpMsgHandler;


### PR DESCRIPTION
Was uint8_t but interpreted as a bool